### PR TITLE
VITE-351: Minio does not allow paylaods over 1MB

### DIFF
--- a/templates/nginx.tmpl
+++ b/templates/nginx.tmpl
@@ -283,6 +283,9 @@ server {
 	{{ end }}
 
 	{{ template "ssl_policy" (dict "ssl_policy" $ssl_policy) }}
+	
+	# Disable body size checking
+	client_max_body_size 0;
 
 	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;


### PR DESCRIPTION
This has been tested on our VM and it resolves the issue.